### PR TITLE
中途merge

### DIFF
--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -38,4 +38,15 @@ class Jad_Admin_Page extends Jad_Base {
 			[ $this, 'settings_page' ],
 		);
 	}
+
+	/**
+	 * Add configuration link to plugin page.
+	 *
+	 * @param array|string $links plugin page setting links.
+	 */
+	public function add_settings_links( array $links ): array {
+		$add_link = '<a href="options-general.php?page=' . self::PLUGIN_SLUG . '">' . __( 'Settings' ) . '</a>';
+		array_unshift( $links, $add_link );
+		return $links;
+	}
 }

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -52,6 +52,27 @@ class Jad_Admin_Page extends Jad_Base {
 	}
 
 	/**
+	 * Include JS in Send Chat Tools settings page.
+	 *
+	 * @param string $hook_suffix WordPress hook_suffix.
+	 */
+	public function add_scripts( string $hook_suffix ): void {
+		if ( 'settings_page_' . self::PLUGIN_SLUG !== $hook_suffix ) {
+			return;
+		}
+
+		$assets = require_once $this->get_plugin_dir( 'jad-console' ) . '/build/index.asset.php';
+
+		wp_enqueue_script(
+			$this->add_prefix( 'script' ),
+			$this->get_plugin_url( self::PLUGIN_SLUG ) . '/build/index.js',
+			$assets['dependencies'],
+			$assets['version'],
+			true
+		);
+	}
+
+	/**
 	 * Settings page.
 	 */
 	public function settings_page(): void {

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -50,4 +50,11 @@ class Jad_Admin_Page extends Jad_Base {
 		array_unshift( $links, $add_link );
 		return $links;
 	}
+
+	/**
+	 * Settings page.
+	 */
+	public function settings_page(): void {
+		echo '<div id="' . esc_attr( self::PLUGIN_SLUG . '-settings' ) . '"></div>';
+	}
 }

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -24,6 +24,7 @@ class Jad_Admin_Page extends Jad_Base {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
+		add_action( 'admin_enqueue_scripts', [ $this, 'add_scripts' ] );
 		add_filter( 'plugin_action_links_' . plugin_basename( $this->get_plugin_path() ), [ $this, 'add_settings_links' ] );
 	}
 

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -18,4 +18,10 @@ if ( ! defined( 'ABSPATH' ) ) {
  * JAd Console settings page.
  */
 class Jad_Admin_Page {
+	/**
+	 * WordPress hook.
+	 * Add settings page link in admin page.
+	 */
+	public function __construct() {
+	}
 }

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -23,6 +23,7 @@ class Jad_Admin_Page extends Jad_Base {
 	 * Add settings page link in admin page.
 	 */
 	public function __construct() {
+		add_action( 'admin_menu', [ $this, 'add_menu' ] );
 	}
 
 	/**

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -17,5 +17,5 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * JAd Console settings page.
  */
-class Jad_Settings {
+class Jad_Admin_Page {
 }

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -24,4 +24,17 @@ class Jad_Admin_Page extends Jad_Base {
 	 */
 	public function __construct() {
 	}
+
+	/**
+	 * Add Setting menu.
+	 */
+	public function add_menu(): void {
+		add_options_page(
+			__( 'JAd Console', 'jad-console' ),
+			__( 'JAd Console', 'jad-console' ),
+			'manage_options',
+			self::PLUGIN_SLUG,
+			[ $this, 'settings_page' ],
+		);
+	}
 }

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * JAd Console settings page.
  */
-class Jad_Admin_Page {
+class Jad_Admin_Page extends Jad_Base {
 	/**
 	 * WordPress hook.
 	 * Add settings page link in admin page.

--- a/classes/class-jad-admin-page.php
+++ b/classes/class-jad-admin-page.php
@@ -24,6 +24,7 @@ class Jad_Admin_Page extends Jad_Base {
 	 */
 	public function __construct() {
 		add_action( 'admin_menu', [ $this, 'add_menu' ] );
+		add_filter( 'plugin_action_links_' . plugin_basename( $this->get_plugin_path() ), [ $this, 'add_settings_links' ] );
 	}
 
 	/**

--- a/classes/class-jad-settings.php
+++ b/classes/class-jad-settings.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * JAd Console settings page.
+ *
+ * @author Ken-chan
+ * @package WordPress
+ * @subpackage JAd Console
+ * @since 0.0.1
+ */
+
+declare( strict_types = 1 );
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 'You do not have access rights.' );
+}
+
+/**
+ * JAd Console settings page.
+ */
+class Jad_Settings {
+}

--- a/jad-console.php
+++ b/jad-console.php
@@ -36,4 +36,12 @@ if ( ! $jad_phpver_judge->judgment( $require_php_version ) ) {
 		$require_php_version,
 		is_admin(),
 	);
+} else {
+	require_once __DIR__ . '/classes/class-jad-base.php';
+	require_once __DIR__ . '/classes/class-jad-admin-page.php';
+
+	/**
+	 * Admin page.
+	 */
+	new Jad_Admin_Page();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "JAd-Console",
+  "name": "jad-console",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -8,6 +8,7 @@
         "@wordpress/env": "^8.8.0",
         "@wordpress/scripts": "^26.13.0",
         "esbuild-loader": "^4.0.2",
+        "eslint-import-resolver-typescript": "^3.6.1",
         "fork-ts-checker-webpack-plugin": "^8.0.0",
         "thread-loader": "^4.0.2"
       }
@@ -8928,6 +8929,31 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "@wordpress/env": "^8.8.0",
     "@wordpress/scripts": "^26.13.0",
     "esbuild-loader": "^4.0.2",
+    "eslint-import-resolver-typescript": "^3.6.1",
     "fork-ts-checker-webpack-plugin": "^8.0.0",
     "thread-loader": "^4.0.2"
   },

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,4 @@
-import { render } from '@wordpress/element';
+import { createRoot } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 const AdminPage = () => {
@@ -9,4 +9,5 @@ const AdminPage = () => {
 	);
 };
 
-render( <AdminPage />, document.getElementById( 'jad-console-settings' ) );
+const root = createRoot( document.getElementById( 'jad-console-settings' ) as Element );
+root.render( <AdminPage /> );

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,12 @@
+import { render } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+
+const AdminPage = () => {
+	return (
+		<div>
+			<h1>{ __( 'JAd Console設定', 'jad-console' ) }</h1>
+		</div>
+	);
+};
+
+render( <AdminPage />, document.getElementById( 'jad-console-settings' ) );


### PR DESCRIPTION
先に #13 を実装してからAPI周りの定義を実装する。

- refs #11 intiial commit
- refs #11 fix rename use admin-page -> file, class
- refs #11 add constructor
- refs #11 fix extends Jad_Base
- refs #11 add add_menu method
- refs #11 add add_menu use add_action hook
- refs #11 add admin page start
- refs #11 add add_settings_links method
- refs #11 add plugin_action_links hook
- refs #11 add settings_page method
- refs #11 initial commit
- refs #11 add package -> eslint-import-resolver-typescript
- refs #11 add main container
- refs #11 add add_scripts method
- refs #11 add admin_enqueue_scripts WordPress hook
- refs #11 fix use createRoot
