### PR TITLE
30 fix use notify api value

### DIFF
--- a/classes/class-jad-ad-policy-notice.php
+++ b/classes/class-jad-ad-policy-notice.php
@@ -22,9 +22,21 @@ class Jad_Ad_Policy_Notice extends Jad_Base {
 	 * WordPress hook.
 	 */
 	public function __construct() {
-		add_action( 'wp_enqueue_scripts', [ $this, 'add_scripts' ] );
-		add_action( 'wp_footer', [ $this, 'show_ad_policy' ], 1 );
-		add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );
+
+		add_action(
+			'init',
+			function () {
+
+				$jad_options = get_option( $this->add_prefix( 'options' ) );
+				if ( ! $jad_options['plugin_enabled'] || ( is_user_logged_in() && $jad_options['admin_mode_enable'] ) ) {
+					return;
+				}
+
+				add_action( 'wp_enqueue_scripts', [ $this, 'add_scripts' ] );
+				add_action( 'wp_footer', [ $this, 'show_ad_policy' ], 1 );
+				add_action( 'rest_api_init', [ $this, 'register_rest_api' ] );
+			}
+		);
 	}
 
 	/**

--- a/src/ad-policy-notify/components/MinimizerToggle.tsx
+++ b/src/ad-policy-notify/components/MinimizerToggle.tsx
@@ -19,12 +19,12 @@ const AdPolicyNotifyOpenButtonStyle = css`
 	bottom: 30px;
 	left: 20px;
 	font-size: 1rem;
-	color: #fff;
-	background-color: #1a1a1a;
+	color: #1a1a1a;
+	background-color: rgba( 165, 255, 201, 1 );
 	height: 80px;
 	width: 80px;
 	border-radius: 50%;
 	border: none;
 	cursor: pointer;
-	box-shadow: 0 0 3px 1px rgba( 0, 0, 0, 0.5 );
+	box-shadow: 0 0 3px 1px rgba( 117, 182, 143, 0.5 );
 `;

--- a/src/ad-policy-notify/components/ShowNotify.tsx
+++ b/src/ad-policy-notify/components/ShowNotify.tsx
@@ -49,8 +49,7 @@ const AdPolicyNotifyWrapperStyle = css`
 	bottom: 0;
 	width: 100%;
 	color: #fff;
-	background-color: #1a1a1a;
-	opacity: 0.95;
+	background-color: rgba( 26, 26, 26, 0.95 );
 	z-index: 9999;
 	padding-top: 15px;
 	padding-bottom: 15px;

--- a/src/ad-policy-notify/components/ShowNotify.tsx
+++ b/src/ad-policy-notify/components/ShowNotify.tsx
@@ -39,9 +39,6 @@ export const ShowNotify = ( props: propsType ) => {
 						同意する
 					</button>
 				</div>
-				<p className={ AdPolicyNotifyAnnotationStyle }>
-					※このメッセージは同意して頂いた場合、7日間非表示になります。
-				</p>
 			</div>
 		</div>
 	);
@@ -88,12 +85,6 @@ const AdPolicyNotifyButtonStyle = css`
 	padding: 10px 30px;
 	background-color: #fff;
 	border-radius: 10px;
-`;
-
-const AdPolicyNotifyAnnotationStyle = css`
-	font-size: 0.8rem;
-	flex-grow: 1;
-	text-align: center;
 `;
 
 const AdPolicyNotifyHiddenStyle = css`

--- a/src/ad-policy-notify/components/ShowNotify.tsx
+++ b/src/ad-policy-notify/components/ShowNotify.tsx
@@ -5,6 +5,23 @@ import { propsType } from 'src/ad-policy-notify/types/propsType';
 export const ShowNotify = ( props: propsType ) => {
 	const { notifyHidden, setNotifyHidden, apiData } = props;
 
+	const policyPage = () => {
+		if ( apiData?.policy_page_url ) {
+			const anchor =
+				<a href={ apiData.policy_page_url } className={ AdPolicyNotifyPolicyUrlStyle }>
+					広告ポリシー
+				</a>;
+
+			return (
+				<>
+					詳しくは{ anchor }をご覧ください。
+				</>
+			);
+		}
+
+		return null;
+	};
+
 	return (
 		<div className={
 			notifyHidden ? AdPolicyNotifyHiddenStyle : AdPolicyNotifyWrapperStyle
@@ -12,6 +29,7 @@ export const ShowNotify = ( props: propsType ) => {
 			<div className={ AdPolicyNotifyContentStyle }>
 				<p className={ AdPolicyNotifyMessageStyle }>
 					{ apiData?.main_message }
+					{ policyPage() }
 				</p>
 				<div className={ AdPolicyNotifyButtonWrapperStyle }>
 					<button
@@ -56,6 +74,10 @@ const AdPolicyNotifyContentStyle = css`
 const AdPolicyNotifyMessageStyle = css`
 	width: 80%;
 	text-align: center;
+`;
+
+const AdPolicyNotifyPolicyUrlStyle = css`
+	color: #fff;
 `;
 
 const AdPolicyNotifyButtonWrapperStyle = css`

--- a/src/ad-policy-notify/components/ShowNotify.tsx
+++ b/src/ad-policy-notify/components/ShowNotify.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { propsType } from 'src/ad-policy-notify/types/propsType';
 
 export const ShowNotify = ( props: propsType ) => {
-	const { notifyHidden, setNotifyHidden } = props;
+	const { notifyHidden, setNotifyHidden, apiData } = props;
 
 	return (
 		<div className={
@@ -11,7 +11,7 @@ export const ShowNotify = ( props: propsType ) => {
 		}>
 			<div className={ AdPolicyNotifyContentStyle }>
 				<p className={ AdPolicyNotifyMessageStyle }>
-					当サイトでは記事の一部で広告を配信しています。詳しくは広告ポリシーをご覧ください。
+					{ apiData?.main_message }
 				</p>
 				<div className={ AdPolicyNotifyButtonWrapperStyle }>
 					<button

--- a/src/ad-policy-notify/components/ShowNotify.tsx
+++ b/src/ad-policy-notify/components/ShowNotify.tsx
@@ -1,5 +1,13 @@
-import { css } from '@emotion/css';
 
+import {
+	AdPolicyNotifyButtonStyle,
+	AdPolicyNotifyButtonWrapperStyle,
+	AdPolicyNotifyContentStyle,
+	AdPolicyNotifyHiddenStyle,
+	AdPolicyNotifyMessageStyle,
+	AdPolicyNotifyPolicyUrlStyle,
+	AdPolicyNotifyWrapperStyle,
+} from 'src/ad-policy-notify/styles/style';
 import { propsType } from 'src/ad-policy-notify/types/propsType';
 
 export const ShowNotify = ( props: propsType ) => {
@@ -43,49 +51,3 @@ export const ShowNotify = ( props: propsType ) => {
 		</div>
 	);
 };
-
-const AdPolicyNotifyWrapperStyle = css`
-	position: fixed;
-	bottom: 0;
-	width: 100%;
-	color: #fff;
-	background-color: rgba( 26, 26, 26, 0.95 );
-	z-index: 9999;
-	padding-top: 15px;
-	padding-bottom: 15px;
-`;
-
-const AdPolicyNotifyContentStyle = css`
-	display: flex;
-	justify-content: center;
-	align-items: center;
-	flex-wrap: wrap;
-	margin: 0 150px;
-
-	@media screen and ( max-width: 768px ) {
-		margin: 0px;
-	}
-`;
-
-const AdPolicyNotifyMessageStyle = css`
-	width: 80%;
-	text-align: center;
-`;
-
-const AdPolicyNotifyPolicyUrlStyle = css`
-	color: #fff;
-`;
-
-const AdPolicyNotifyButtonWrapperStyle = css`
-	width: 20%;
-`;
-
-const AdPolicyNotifyButtonStyle = css`
-	padding: 10px 30px;
-	background-color: #fff;
-	border-radius: 10px;
-`;
-
-const AdPolicyNotifyHiddenStyle = css`
-	display: none;
-`;

--- a/src/ad-policy-notify/index.tsx
+++ b/src/ad-policy-notify/index.tsx
@@ -9,7 +9,7 @@ import { notifyApiType } from 'src/types/apiType';
 export const AdPolicyNotify = () => {
 	const [ apiData, setApiData ] = useState< notifyApiType | undefined >( undefined );
 	const [ apiError, setApiError ] = useState( false );
-	const [ notifyHidden, setNotifyHidden ] = useState( true );
+	const [ notifyHidden, setNotifyHidden ] = useState( false );
 
 	useGetApi( 'notify', setApiData, setApiError );
 

--- a/src/ad-policy-notify/index.tsx
+++ b/src/ad-policy-notify/index.tsx
@@ -2,13 +2,20 @@ import { createRoot, useState } from '@wordpress/element';
 
 import { MinimizerToggle } from 'src/ad-policy-notify/components/MinimizerToggle';
 import { ShowNotify } from 'src/ad-policy-notify/components/ShowNotify';
+import { useGetApi } from 'src/hooks/useGetApi';
+
+import { notifyApiType } from 'src/types/apiType';
 
 export const AdPolicyNotify = () => {
+	const [ apiData, setApiData ] = useState< notifyApiType | undefined >( undefined );
+	const [ apiError, setApiError ] = useState( false );
 	const [ notifyHidden, setNotifyHidden ] = useState( true );
+
+	useGetApi( 'notify', setApiData, setApiError );
 
 	return (
 		<>
-			{ notifyHidden ? (
+			{ ! apiError && apiData && notifyHidden ? (
 				<MinimizerToggle
 					notifyHidden={ notifyHidden }
 					setNotifyHidden={ setNotifyHidden }

--- a/src/ad-policy-notify/index.tsx
+++ b/src/ad-policy-notify/index.tsx
@@ -15,17 +15,19 @@ export const AdPolicyNotify = () => {
 
 	return (
 		<>
-			{ ! apiError && apiData && notifyHidden ? (
+			{ ! apiError && apiData && ( notifyHidden ? (
 				<MinimizerToggle
 					notifyHidden={ notifyHidden }
 					setNotifyHidden={ setNotifyHidden }
+					apiData={ apiData }
 				/>
 			) : (
 				<ShowNotify
 					notifyHidden={ notifyHidden }
 					setNotifyHidden={ setNotifyHidden }
+					apiData={ apiData }
 				/>
-			) }
+			) ) }
 		</>
 	);
 };

--- a/src/ad-policy-notify/styles/style.ts
+++ b/src/ad-policy-notify/styles/style.ts
@@ -1,0 +1,47 @@
+import { css } from '@emotion/css';
+
+export const AdPolicyNotifyWrapperStyle = css`
+	position: fixed;
+	bottom: 0;
+	width: 100%;
+	color: #fff;
+	background-color: rgba( 26, 26, 26, 0.95 );
+	z-index: 9999;
+	padding-top: 15px;
+	padding-bottom: 15px;
+`;
+
+export const AdPolicyNotifyContentStyle = css`
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	flex-wrap: wrap;
+	margin: 0 150px;
+
+	@media screen and ( max-width: 768px ) {
+		margin: 0px;
+	}
+`;
+
+export const AdPolicyNotifyMessageStyle = css`
+	width: 80%;
+	text-align: center;
+`;
+
+export const AdPolicyNotifyPolicyUrlStyle = css`
+	color: #fff;
+`;
+
+export const AdPolicyNotifyButtonWrapperStyle = css`
+	width: 20%;
+`;
+
+export const AdPolicyNotifyButtonStyle = css`
+	padding: 10px 30px;
+	background-color: #fff;
+	border-radius: 10px;
+`;
+
+export const AdPolicyNotifyHiddenStyle = css`
+	display: none;
+`;

--- a/src/ad-policy-notify/styles/style.ts
+++ b/src/ad-policy-notify/styles/style.ts
@@ -37,9 +37,14 @@ export const AdPolicyNotifyButtonWrapperStyle = css`
 `;
 
 export const AdPolicyNotifyButtonStyle = css`
-	padding: 10px 30px;
-	background-color: #fff;
-	border-radius: 10px;
+	padding: .7rem 2rem;
+	background-color: rgba( 255, 255, 255, 1 );
+	box-sizing: border-box;
+	border: none;
+	outline: none;
+	border-radius: .5rem;
+	user-select: none;
+	white-space: nowrap;
 `;
 
 export const AdPolicyNotifyHiddenStyle = css`

--- a/src/ad-policy-notify/styles/style.ts
+++ b/src/ad-policy-notify/styles/style.ts
@@ -37,8 +37,9 @@ export const AdPolicyNotifyButtonWrapperStyle = css`
 `;
 
 export const AdPolicyNotifyButtonStyle = css`
-	padding: .7rem 2rem;
+	padding: .7rem 4rem;
 	background-color: rgba( 255, 255, 255, 1 );
+	background-color: rgba( 165, 255, 201, 1 );
 	box-sizing: border-box;
 	border: none;
 	outline: none;

--- a/src/ad-policy-notify/types/propsType.ts
+++ b/src/ad-policy-notify/types/propsType.ts
@@ -1,6 +1,9 @@
 import { Dispatch, SetStateAction } from 'react';
 
+import { notifyApiType } from 'src/types/apiType';
+
 export type propsType = {
 	notifyHidden: boolean,
 	setNotifyHidden: Dispatch<SetStateAction< boolean > >
+	apiData: notifyApiType
 }

--- a/src/hooks/useGetApi.ts
+++ b/src/hooks/useGetApi.ts
@@ -3,15 +3,15 @@ import { Dispatch, SetStateAction } from 'react';
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect } from '@wordpress/element';
 
-import { apiType, endPointType } from 'src/types/apiType';
+import { endPointType } from 'src/types/apiType';
 
-export const useGetApi = (
+export const useGetApi = < T, >(
 	endPoint: endPointType,
-	stateFunc: Dispatch< SetStateAction< apiType | undefined > >,
+	stateFunc: Dispatch< SetStateAction< T | undefined > >,
 	setApiError: Dispatch< SetStateAction< boolean > >,
 ) => {
 	useEffect( () => {
-		apiFetch< apiType >(
+		apiFetch< T >(
 			{ path: `/jad-console/v1/${ endPoint }` }
 		).then( ( response ) => {
 			setApiError( false );

--- a/src/types/apiType.ts
+++ b/src/types/apiType.ts
@@ -6,6 +6,8 @@ export type apiType = {
 	policy_page_url: string;
 }
 
+export type notifyApiType = Pick<apiType, 'design_type' | 'main_message' | 'policy_page_url'>;
+
 export type itemKeyType = keyof apiType;
 
 export type useSetApiType = {


### PR DESCRIPTION
- refs #30 fix use generics
- refs #30 add notifyApiType
- refs #30 add apiData, apiError -> useState, useGetApi
- refs #30 use apiData
- refs #30 add apiData -> propsType
- refs #30 add apiData
- refs #30 add use apiData -> policy_page_url, generate ad policy link
- refs #30 remove Annotation element, style
- refs #30 remove opacity, use rgba
- refs #30 fix export style, use style.ts styles
- refs #30 initial commit
- refs #30 fix AdPolicyNotifyButtonStyle -> use rem, rgba, add border, outline, user-select and white-space
- refs #30 fix notifyHidden initial value
- refs #30 fix styles
- refs #30 fix styles
- refs #30 fix action hook wrap hook -> use init
